### PR TITLE
Fixes to allow running when dependencies aren't installed directly in module folder

### DIFF
--- a/tasks/phantom_benchmark.js
+++ b/tasks/phantom_benchmark.js
@@ -44,8 +44,8 @@ module.exports = function( grunt ) {
     });
 
     options.inject = ([
-      path.join( __dirname, '..', '/node_modules/lodash/dist/lodash.js' ),
-      path.join( __dirname, '..', '/node_modules/benchmark/benchmark.js' ),
+      require.resolve('lodash'),
+      require.resolve('benchmark'),
       path.join( __dirname,'scripts/setup.js' )
     ]).concat( options.inject );
 

--- a/tasks/scripts/setup.js
+++ b/tasks/scripts/setup.js
@@ -3,6 +3,10 @@ function sendMessage() {
   alert( JSON.stringify( args ) );
 }
 
+window.onerror = function( e ) {
+  sendMessage( 'benchmark.error', e );
+};
+
 // create the benchmark suite
 var suite = new Benchmark.Suite();
 
@@ -13,7 +17,3 @@ suite.on( 'cycle', function( event ) {
 suite.on( 'complete', function() {
   sendMessage('benchmark.done');
 });
-
-window.onerror = function( e ) {
-  sendMessage( 'benchmark.error', e );
-};


### PR DESCRIPTION
It appears that the dependencies aren't always installed in the plugin's own `node_modules` folder, therefore the task needs some slight adjustments to be able to find and reference the relevant files wherever they end up installed.